### PR TITLE
feature/added-images

### DIFF
--- a/app/(tabs)/scale.tsx
+++ b/app/(tabs)/scale.tsx
@@ -16,6 +16,18 @@ import { useCallback, useState } from "react";
 import { useFocusEffect } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
 
+/**
+ * Screen component that displays a daily nutrition summary and a horizontal food log.
+ *
+ * Loads log entries from a local SQLite database (all entries with date < UTC midnight of today), enriches each log with its food item data, and maintains them in component state. Shows totals for calories, protein, carbs, and fats; renders logged foods as tappable cards that navigate to a nutrition detail screen; and allows removing a log entry which updates local state and deletes the row from the database.
+ *
+ * Side effects:
+ * - Reads from the SQLite database on screen focus.
+ * - Deletes rows from the `log_entries` table when a user taps Delete.
+ * - Navigates to `/nutrition/[id]` when a food card is pressed.
+ *
+ * @returns A React element for the nutrition summary screen.
+ */
 export default function ScaleScreen() {
   const [logEntries, setLogEntries] = useState<any[]>([]);
 

--- a/app/(tabs)/scale.tsx
+++ b/app/(tabs)/scale.tsx
@@ -6,10 +6,11 @@ import {
   Text,
   Dimensions,
   ScrollView,
+  Pressable,
 } from "react-native";
 
 import ParallaxScrollView from "@/components/ParallaxScrollView";
-import { Link } from "expo-router";
+import { Link, useRouter } from "expo-router";
 import { useSQLiteContext } from "expo-sqlite";
 import { useCallback, useState } from "react";
 import { useFocusEffect } from "expo-router";
@@ -22,6 +23,7 @@ export default function ScaleScreen() {
   const { height } = Dimensions.get("window");
   const date = new Date();
   const midnight = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, 0)).toISOString();
+  const router = useRouter();
   const months = [
     "Jan", "Feb", "Mar", "Apr", "May", "Jun",
     "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
@@ -40,7 +42,6 @@ export default function ScaleScreen() {
 
   const loadData = async () => {
     try {
-      console.log("called");
       const result = await db.getAllAsync("SELECT * FROM log_entries WHERE date  < ? ORDER BY date DESC", [midnight]);
       console.log("Query result:", result);
       const entries: any = [];
@@ -60,14 +61,6 @@ export default function ScaleScreen() {
       loadData();
     }, [])
   );
-
-  // if (!logEntries) {
-  //   return (
-  //     <View>
-  //       <Text style={{color: "white"}}>Loading...</Text>
-  //     </View>
-  //   );
-  // }
 
   return (
     <SafeAreaView style={styles.mainContainer}>
@@ -103,18 +96,24 @@ export default function ScaleScreen() {
           </View>
           <View style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
             <Text style={{ fontSize: 20, fontWeight: 'semibold', marginTop: 20 }}>Food log</Text>
-            <Link href="/nutrition/1">Quick Add</Link>
+            {/* <Link href="/nutrition/1">Quick Add</Link> */}
           </View>
           {logEntries.length > 0 ?
             <FlatList data={logEntries} renderItem={(log_entry: any) => {
               const entry = log_entry.item;
               return (
-                <View key={entry.id} style={{ height: 300, width: 300, backgroundColor: 'lavender', marginRight: 10, borderRadius: 40, padding: 25 }}>
-                  <Text>
-                    {entry.name}
-                  </Text>
-                  <Button onPress={() => handleDelete(entry.entry_id)} title="Delete" />
-                </View>
+                <Pressable onPress={() =>
+                  router.navigate({
+                    pathname: '/nutrition/[id]',
+                    params: { id: entry.id }
+                  })} >
+                  <View key={entry.id} style={{ height: 300, width: 300, backgroundColor: 'lavender', marginRight: 10, borderRadius: 40, padding: 25 }}>
+                    <Text>
+                      {entry.name}
+                    </Text>
+                    <Button onPress={() => handleDelete(entry.entry_id)} title="Delete" />
+                  </View>
+                </Pressable>
               )
             }
             }
@@ -129,7 +128,7 @@ export default function ScaleScreen() {
             )}
         </View>
       </ScrollView>
-    </SafeAreaView>
+    </SafeAreaView >
   );
 }
 

--- a/app/(tabs)/scan/index.tsx
+++ b/app/(tabs)/scan/index.tsx
@@ -25,6 +25,28 @@ interface FoodDataResponse {
   product: Product;
 }
 
+/**
+ * React Native screen that uses the device camera to scan barcodes and open a scanned food item's detail view.
+ *
+ * Renders a camera view (when permission is granted and the screen is focused), debounces duplicate/rapid scans,
+ * checks the local SQLite `food_items` table for an existing entry by EAN barcode, and if not present fetches product
+ * data from the Open Food Facts API and inserts a new row. On successful lookup or insertion the component navigates
+ * to `/scan/[id]` using the scanned barcode as `id`. If the remote lookup or insert fails an alert is shown.
+ *
+ * Behavior notes:
+ * - Prevents duplicate handling by ignoring scans within 500ms, repeated scans of the same barcode, or while a lookup
+ *   is already in progress.
+ * - Stores the API-provided `image_small_url` into the database `image_url` column when inserting a new item.
+ * - Only renders the camera while the screen is focused.
+ *
+ * Side effects:
+ * - Reads from and writes to the app's SQLite database.
+ * - Performs network requests to Open Food Facts.
+ * - Navigates via the app router and may display an Alert on error.
+ *
+ * Returns:
+ * - A React element for the scanner screen.
+ */
 export default function Scanner() {
   const [facing, setFacing] = useState<CameraType>('back');
   const [permission, requestPermission] = useCameraPermissions();

--- a/app/(tabs)/scan/index.tsx
+++ b/app/(tabs)/scan/index.tsx
@@ -17,6 +17,7 @@ interface Nutriments {
 interface Product {
   brands: string; // The brand name of the product [cite: 3]
   product_name: string; // The name of the product [cite: 107]
+  image_small_url: string;
   nutriments: Nutriments; // Nested object containing nutritional facts
 }
 
@@ -72,10 +73,11 @@ export default function Scanner() {
           }
         });
         const respData: FoodDataResponse = await response.json();
-        const result = await db.runAsync("INSERT INTO food_items (ean_id,name,brand,calories,g_protein,g_carbs,g_fats,g_fiber,g_sodium) VALUES (?,?,?,?,?,?,?,?,?)", [
+        const result = await db.runAsync("INSERT INTO food_items (ean_id,name,brand,image_url,calories,g_protein,g_carbs,g_fats,g_fiber,g_sodium) VALUES (?,?,?,?,?,?,?,?,?,?)", [
           data.data,
           respData.product.product_name,
           respData.product.brands,
+          respData.product.image_small_url,
           respData.product.nutriments['energy-kcal'],
           respData.product.nutriments.proteins,
           respData.product.nutriments.carbohydrates,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,12 +21,12 @@ export default function RootLayout() {
   const createIfNeeded = async (db: SQLiteDatabase) => {
     console.log("creating food_items table if needed");
     await db.runAsync(
-      "CREATE TABLE IF NOT EXISTS food_items (id INTEGER PRIMARY KEY AUTOINCREMENT, ean_id TEXT, name TEXT NOT NULL, brand TEXT, g_amount REAL, calories REAL NOT NULL, g_protein REAL NOT NULL, g_carbs REAL NOT NULL, g_fats REAL NOT NULL, g_fiber REAL, g_sodium REAL, is_quick_add BOOLEAN);"
+      "CREATE TABLE IF NOT EXISTS food_items (id INTEGER PRIMARY KEY AUTOINCREMENT, ean_id TEXT, name TEXT NOT NULL, brand TEXT, image_url TEXT, g_amount REAL, calories REAL NOT NULL, g_protein REAL NOT NULL, g_carbs REAL NOT NULL, g_fats REAL NOT NULL, g_fiber REAL, g_sodium REAL, is_quick_add BOOLEAN);"
     )
 
     console.log("creating log_entries table if needed");
     await db.runAsync(
-      "CREATE TABLE IF NOT EXISTS log_entries (id INTEGER PRIMARY KEY AUTOINCREMENT, food_item_id INTEGER NOT NULL, date TEXT NOT NULL, FOREIGN KEY (food_item_id) REFERENCES food_items(id));"
+      "CREATE TABLE IF NOT EXISTS log_entries (id INTEGER PRIMARY KEY AUTOINCREMENT, food_item_id INTEGER NOT NULL, serving_size_g REAL NOT NULL, date TEXT NOT NULL, FOREIGN KEY (food_item_id) REFERENCES food_items(id));"
     )
 
     console.log("creating recipes table if needed");

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,6 +7,21 @@ import 'react-native-reanimated';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { SQLiteDatabase, SQLiteProvider } from 'expo-sqlite';
 
+/**
+ * Root-level layout for the app — initializes runtime dependencies and renders the app shell.
+ *
+ * Sets up the SQLite database (creates required tables if they do not exist), loads the SpaceMono font
+ * before rendering, applies theming based on the current color scheme, and defines the primary navigation stack.
+ *
+ * Database initialization (performed via the provider's `onInit` callback) ensures these tables exist:
+ * - food_items (columns include id, ean_id, name, brand, image_url, g_amount, calories, g_protein, g_carbs, g_fats, g_fiber, g_sodium, is_quick_add)
+ * - log_entries (columns include id, food_item_id, serving_size_g, date; `food_item_id` references food_items.id)
+ * - recipes (columns include id, name, g_amount, calories, g_protein, g_carbs, g_fats)
+ *
+ * Note: While fonts are loading this component returns null (renders nothing) until the SpaceMono font is ready.
+ *
+ * @returns The root React element for the application.
+ */
 export default function RootLayout() {
   const colorScheme = useColorScheme();
   const [loaded] = useFonts({

--- a/app/nutrition/[id].tsx
+++ b/app/nutrition/[id].tsx
@@ -1,5 +1,15 @@
 import { useLocalSearchParams } from "expo-router"
 import { View, Text } from "react-native"
+/**
+ * React Native screen that displays basic information for a food item.
+ *
+ * Reads the `id` from the router's local search parameters and renders a simple view
+ * showing "Food info page <id>".
+ *
+ * The component does not perform loading/error handling or fetch additional data.
+ *
+ * @returns A React element representing the food info screen.
+ */
 export default function foodInfo() {
   const data = useLocalSearchParams<{ id: string }>();
   return (

--- a/app/nutrition/[id].tsx
+++ b/app/nutrition/[id].tsx
@@ -8,3 +8,5 @@ export default function foodInfo() {
     </View>
   )
 }
+
+

--- a/off_api_resp.txt
+++ b/off_api_resp.txt
@@ -1,0 +1,1312 @@
+{
+  "code": "0860008097699",
+  "product": {
+    "_id": "0860008097699",
+    "_keywords": [
+      "action",
+      "bean",
+      "china",
+      "edamame",
+      "gluten",
+      "gmo",
+      "kosher",
+      "no",
+      "non",
+      "only",
+      "project",
+      "snack",
+      "the",
+      "vegan",
+      "vegetarian"
+    ],
+    "added_countries_tags": [],
+    "additives_n": 0,
+    "additives_original_tags": [],
+    "additives_tags": [],
+    "allergens": "",
+    "allergens_from_ingredients": "en:nuts, en:soybeans, en:soybeans, en:soybeans, Soybean, tree nuts",
+    "allergens_from_user": "(en) ",
+    "allergens_hierarchy": [
+      "en:nuts",
+      "en:soybeans"
+    ],
+    "allergens_lc": "en",
+    "allergens_tags": [
+      "en:nuts",
+      "en:soybeans"
+    ],
+    "amino_acids_tags": [],
+    "brands": "The Only Bean",
+    "brands_tags": [
+      "the-only-bean"
+    ],
+    "categories": "Snacks",
+    "categories_hierarchy": [
+      "en:snacks"
+    ],
+    "categories_lc": "en",
+    "categories_old": "",
+    "categories_properties": {},
+    "categories_properties_tags": [
+      "all-products",
+      "categories-known",
+      "agribalyse-food-code-unknown",
+      "agribalyse-proxy-food-code-unknown",
+      "ciqual-food-code-unknown",
+      "agribalyse-unknown"
+    ],
+    "categories_tags": [
+      "en:snacks"
+    ],
+    "checkers_tags": [],
+    "cities_tags": [],
+    "code": "0860008097699",
+    "codes_tags": [
+      "code-13",
+      "conflict-with-upc-12",
+      "0860008097xxx",
+      "086000809xxxx",
+      "08600080xxxxx",
+      "0860008xxxxxx",
+      "086000xxxxxxx",
+      "08600xxxxxxxx",
+      "0860xxxxxxxxx",
+      "086xxxxxxxxxx",
+      "08xxxxxxxxxxx",
+      "0xxxxxxxxxxxx"
+    ],
+    "compared_to_category": "en:snacks",
+    "complete": 0,
+    "completeness": 0.7875,
+    "correctors_tags": [
+      "roboto-app",
+      "segundo",
+      "annelotte",
+      "macrofactor",
+      "openfoodfacts-contributors"
+    ],
+    "countries": "United States",
+    "countries_hierarchy": [
+      "en:united-states"
+    ],
+    "countries_lc": "en",
+    "countries_tags": [
+      "en:united-states"
+    ],
+    "created_t": 1695300274,
+    "creator": "smoothie-app",
+    "data_quality_bugs_tags": [],
+    "data_quality_errors_tags": [],
+    "data_quality_info_tags": [
+      "en:no-packaging-data",
+      "en:ingredients-percent-analysis-ok",
+      "en:environmental-score-extended-data-not-computed",
+      "en:food-groups-1-unknown",
+      "en:food-groups-2-unknown",
+      "en:food-groups-3-unknown"
+    ],
+    "data_quality_tags": [
+      "en:no-packaging-data",
+      "en:ingredients-percent-analysis-ok",
+      "en:environmental-score-extended-data-not-computed",
+      "en:food-groups-1-unknown",
+      "en:food-groups-2-unknown",
+      "en:food-groups-3-unknown",
+      "en:energy-value-in-kcal-may-not-match-value-computed-from-other-nutrients",
+      "en:nutrition-value-very-high-for-category-fiber",
+      "en:nutrition-value-very-high-for-category-proteins",
+      "en:vegan-label-but-could-not-confirm-for-all-ingredients",
+      "en:vegetarian-label-but-could-not-confirm-for-all-ingredients",
+      "en:environmental-score-packaging-packaging-data-missing",
+      "en:environmental-score-production-system-no-label"
+    ],
+    "data_quality_warnings_tags": [
+      "en:energy-value-in-kcal-may-not-match-value-computed-from-other-nutrients",
+      "en:nutrition-value-very-high-for-category-fiber",
+      "en:nutrition-value-very-high-for-category-proteins",
+      "en:vegan-label-but-could-not-confirm-for-all-ingredients",
+      "en:vegetarian-label-but-could-not-confirm-for-all-ingredients",
+      "en:environmental-score-packaging-packaging-data-missing",
+      "en:environmental-score-production-system-no-label"
+    ],
+    "data_sources": "App - smoothie-openfoodfacts, Apps, App - macrofactor",
+    "data_sources_tags": [
+      "app-smoothie-openfoodfacts",
+      "apps",
+      "app-macrofactor"
+    ],
+    "debug_param_sorted_langs": [
+      "en"
+    ],
+    "ecoscore_data": {
+      "adjustments": {
+        "origins_of_ingredients": {
+          "aggregated_origins": [
+            {
+              "epi_score": 0,
+              "origin": "en:china",
+              "percent": 100,
+              "transportation_score": 0
+            }
+          ],
+          "epi_score": 0,
+          "epi_value": -5,
+          "origins_from_categories": [
+            "en:unknown"
+          ],
+          "origins_from_origins_field": [
+            "en:china"
+          ],
+          "transportation_score": 0,
+          "transportation_scores": {
+            "ad": 13,
+            "al": 27,
+            "at": 2,
+            "ax": 0,
+            "ba": 5,
+            "be": 6,
+            "bg": 7,
+            "ch": 3,
+            "cy": 31,
+            "cz": 0,
+            "de": 6,
+            "dk": 0,
+            "dz": 3,
+            "ee": 2,
+            "eg": 27,
+            "es": 19,
+            "fi": 1,
+            "fo": 0,
+            "fr": 0,
+            "gg": 0,
+            "gi": 21,
+            "gr": 31,
+            "hr": 18,
+            "hu": 0,
+            "ie": 11,
+            "il": 27,
+            "im": 0,
+            "is": 0,
+            "it": 10,
+            "je": 0,
+            "lb": 31,
+            "li": 5,
+            "lt": 0,
+            "lu": 0,
+            "lv": 2,
+            "ly": 28,
+            "ma": 0,
+            "mc": 25,
+            "md": 16,
+            "me": 23,
+            "mk": 14,
+            "mt": 28,
+            "nl": 6,
+            "no": 6,
+            "pl": 0,
+            "ps": 35,
+            "pt": 11,
+            "ro": 17,
+            "rs": 4,
+            "se": 0,
+            "si": 21,
+            "sj": 0,
+            "sk": 0,
+            "sm": 4,
+            "sy": 18,
+            "tn": 27,
+            "tr": 0,
+            "ua": 27,
+            "uk": 1,
+            "us": 0,
+            "va": 0,
+            "world": 0,
+            "xk": 13
+          },
+          "transportation_value": 0,
+          "transportation_values": {
+            "ad": 2,
+            "al": 4,
+            "at": 0,
+            "ax": 0,
+            "ba": 1,
+            "be": 1,
+            "bg": 1,
+            "ch": 0,
+            "cy": 5,
+            "cz": 0,
+            "de": 1,
+            "dk": 0,
+            "dz": 0,
+            "ee": 0,
+            "eg": 4,
+            "es": 3,
+            "fi": 0,
+            "fo": 0,
+            "fr": 0,
+            "gg": 0,
+            "gi": 3,
+            "gr": 5,
+            "hr": 3,
+            "hu": 0,
+            "ie": 2,
+            "il": 4,
+            "im": 0,
+            "is": 0,
+            "it": 2,
+            "je": 0,
+            "lb": 5,
+            "li": 1,
+            "lt": 0,
+            "lu": 0,
+            "lv": 0,
+            "ly": 4,
+            "ma": 0,
+            "mc": 4,
+            "md": 2,
+            "me": 3,
+            "mk": 2,
+            "mt": 4,
+            "nl": 1,
+            "no": 1,
+            "pl": 0,
+            "ps": 5,
+            "pt": 2,
+            "ro": 3,
+            "rs": 1,
+            "se": 0,
+            "si": 3,
+            "sj": 0,
+            "sk": 0,
+            "sm": 1,
+            "sy": 3,
+            "tn": 4,
+            "tr": 0,
+            "ua": 4,
+            "uk": 0,
+            "us": 0,
+            "va": 0,
+            "world": 0,
+            "xk": 2
+          },
+          "value": -5,
+          "values": {
+            "ad": -3,
+            "al": -1,
+            "at": -5,
+            "ax": -5,
+            "ba": -4,
+            "be": -4,
+            "bg": -4,
+            "ch": -5,
+            "cy": 0,
+            "cz": -5,
+            "de": -4,
+            "dk": -5,
+            "dz": -5,
+            "ee": -5,
+            "eg": -1,
+            "es": -2,
+            "fi": -5,
+            "fo": -5,
+            "fr": -5,
+            "gg": -5,
+            "gi": -2,
+            "gr": 0,
+            "hr": -2,
+            "hu": -5,
+            "ie": -3,
+            "il": -1,
+            "im": -5,
+            "is": -5,
+            "it": -3,
+            "je": -5,
+            "lb": 0,
+            "li": -4,
+            "lt": -5,
+            "lu": -5,
+            "lv": -5,
+            "ly": -1,
+            "ma": -5,
+            "mc": -1,
+            "md": -3,
+            "me": -2,
+            "mk": -3,
+            "mt": -1,
+            "nl": -4,
+            "no": -4,
+            "pl": -5,
+            "ps": 0,
+            "pt": -3,
+            "ro": -2,
+            "rs": -4,
+            "se": -5,
+            "si": -2,
+            "sj": -5,
+            "sk": -5,
+            "sm": -4,
+            "sy": -2,
+            "tn": -1,
+            "tr": -5,
+            "ua": -1,
+            "uk": -5,
+            "us": -5,
+            "va": -5,
+            "world": -5,
+            "xk": -3
+          }
+        },
+        "packaging": {
+          "value": -15,
+          "warning": "packaging_data_missing"
+        },
+        "production_system": {
+          "labels": [],
+          "value": 0,
+          "warning": "no_label"
+        },
+        "threatened_species": {}
+      },
+      "agribalyse": {
+        "warning": "missing_agribalyse_match"
+      },
+      "missing": {
+        "agb_category": 1,
+        "labels": 1,
+        "packagings": 1
+      },
+      "missing_agribalyse_match_warning": 1,
+      "missing_key_data": 1,
+      "scores": {},
+      "status": "unknown"
+    },
+    "ecoscore_grade": "unknown",
+    "ecoscore_tags": [
+      "unknown"
+    ],
+    "editors_tags": [
+      "annelotte",
+      "foodvisor",
+      "jessdr",
+      "macrofactor",
+      "openfoodfacts-contributors",
+      "roboto-app",
+      "segundo",
+      "smoothie-app"
+    ],
+    "emb_codes": "",
+    "emb_codes_tags": [],
+    "entry_dates_tags": [
+      "2023-09-21",
+      "2023-09",
+      "2023"
+    ],
+    "expiration_date": "",
+    "food_groups_tags": [],
+    "generic_name": "",
+    "generic_name_en": "",
+    "id": "0860008097699",
+    "image_front_small_url": "https://images.openfoodfacts.net/images/products/086/000/809/7699/front_en.3.200.jpg",
+    "image_front_thumb_url": "https://images.openfoodfacts.net/images/products/086/000/809/7699/front_en.3.100.jpg",
+    "image_front_url": "https://images.openfoodfacts.net/images/products/086/000/809/7699/front_en.3.400.jpg",
+    "image_ingredients_small_url": "https://images.openfoodfacts.net/images/products/086/000/809/7699/ingredients_en.15.200.jpg",
+    "image_ingredients_thumb_url": "https://images.openfoodfacts.net/images/products/086/000/809/7699/ingredients_en.15.100.jpg",
+    "image_ingredients_url": "https://images.openfoodfacts.net/images/products/086/000/809/7699/ingredients_en.15.400.jpg",
+    "image_nutrition_small_url": "https://images.openfoodfacts.net/images/products/086/000/809/7699/nutrition_en.17.200.jpg",
+    "image_nutrition_thumb_url": "https://images.openfoodfacts.net/images/products/086/000/809/7699/nutrition_en.17.100.jpg",
+    "image_nutrition_url": "https://images.openfoodfacts.net/images/products/086/000/809/7699/nutrition_en.17.400.jpg",
+    "image_small_url": "https://images.openfoodfacts.net/images/products/086/000/809/7699/front_en.3.200.jpg",
+    "image_thumb_url": "https://images.openfoodfacts.net/images/products/086/000/809/7699/front_en.3.100.jpg",
+    "image_url": "https://images.openfoodfacts.net/images/products/086/000/809/7699/front_en.3.400.jpg",
+    "images": {
+      "1": {
+        "sizes": {
+          "100": {
+            "h": 100,
+            "w": 75
+          },
+          "400": {
+            "h": 400,
+            "w": 300
+          },
+          "full": {
+            "h": 4032,
+            "w": 3024
+          }
+        },
+        "uploaded_t": 1695300275,
+        "uploader": "smoothie-app"
+      },
+      "2": {
+        "sizes": {
+          "100": {
+            "h": 100,
+            "w": 75
+          },
+          "400": {
+            "h": 400,
+            "w": 300
+          },
+          "full": {
+            "h": 4032,
+            "w": 3024
+          }
+        },
+        "uploaded_t": 1695300315,
+        "uploader": "smoothie-app"
+      },
+      "3": {
+        "sizes": {
+          "100": {
+            "h": 75,
+            "w": 100
+          },
+          "400": {
+            "h": 300,
+            "w": 400
+          },
+          "full": {
+            "h": 3024,
+            "w": 4032
+          }
+        },
+        "uploaded_t": 1695300350,
+        "uploader": "smoothie-app"
+      },
+      "4": {
+        "sizes": {
+          "100": {
+            "h": 100,
+            "w": 75
+          },
+          "400": {
+            "h": 400,
+            "w": 300
+          },
+          "full": {
+            "h": 4032,
+            "w": 3024
+          }
+        },
+        "uploaded_t": 1695300400,
+        "uploader": "smoothie-app"
+      },
+      "5": {
+        "sizes": {
+          "100": {
+            "h": 100,
+            "w": 83
+          },
+          "400": {
+            "h": 400,
+            "w": 333
+          },
+          "full": {
+            "h": 600,
+            "w": 500
+          }
+        },
+        "uploaded_t": 1710372452,
+        "uploader": "foodvisor"
+      },
+      "front_en": {
+        "imgid": "1",
+        "rev": "3",
+        "sizes": {
+          "100": {
+            "h": 100,
+            "w": 75
+          },
+          "200": {
+            "h": 200,
+            "w": 150
+          },
+          "400": {
+            "h": 400,
+            "w": 300
+          },
+          "full": {
+            "h": 4032,
+            "w": 3024
+          }
+        }
+      },
+      "ingredients_en": {
+        "coordinates_image_size": "full",
+        "imgid": "2",
+        "rev": "15",
+        "sizes": {
+          "100": {
+            "h": 45,
+            "w": 100
+          },
+          "200": {
+            "h": 91,
+            "w": 200
+          },
+          "400": {
+            "h": 182,
+            "w": 400
+          },
+          "full": {
+            "h": 1008,
+            "w": 2221
+          }
+        },
+        "x1": 330,
+        "x2": 2551,
+        "y1": 1369,
+        "y2": 2377
+      },
+      "nutrition_en": {
+        "angle": 270,
+        "coordinates_image_size": "full",
+        "imgid": "3",
+        "rev": "17",
+        "sizes": {
+          "100": {
+            "h": 100,
+            "w": 45
+          },
+          "200": {
+            "h": 200,
+            "w": 89
+          },
+          "400": {
+            "h": 400,
+            "w": 179
+          },
+          "full": {
+            "h": 3820,
+            "w": 1705
+          }
+        },
+        "x1": 719,
+        "x2": 2424,
+        "y1": 154,
+        "y2": 3974
+      }
+    },
+    "informers_tags": [
+      "smoothie-app",
+      "roboto-app",
+      "annelotte",
+      "macrofactor",
+      "jessdr",
+      "openfoodfacts-contributors"
+    ],
+    "ingredients": [
+      {
+        "ciqual_food_code": "20901",
+        "id": "en:edamame",
+        "ingredients": [
+          {
+            "ciqual_food_code": "20901",
+            "id": "en:soya-bean",
+            "is_in_taxonomy": 1,
+            "percent_estimate": 60,
+            "percent_max": 100,
+            "percent_min": 20,
+            "text": "Soybean",
+            "vegan": "yes",
+            "vegetarian": "yes"
+          }
+        ],
+        "is_in_taxonomy": 1,
+        "percent_estimate": 60,
+        "percent_max": 100,
+        "percent_min": 20,
+        "text": "Edamame",
+        "vegan": "yes",
+        "vegetarian": "yes"
+      },
+      {
+        "ciqual_food_code": "11082",
+        "id": "en:sea-salt",
+        "is_in_taxonomy": 1,
+        "percent_estimate": 20,
+        "percent_max": 50,
+        "percent_min": 0,
+        "text": "Sea Salt",
+        "vegan": "yes",
+        "vegetarian": "yes"
+      },
+      {
+        "ciqual_food_code": "17420",
+        "from_palm_oil": "no",
+        "id": "en:soya-oil",
+        "is_in_taxonomy": 1,
+        "percent_estimate": 10,
+        "percent_max": 33.3333333333333,
+        "percent_min": 0,
+        "text": "Soybean Oil",
+        "vegan": "yes",
+        "vegetarian": "yes"
+      },
+      {
+        "id": "en:facility-that-processes-peanuts",
+        "is_in_taxonomy": 0,
+        "percent_estimate": 5,
+        "percent_max": 25,
+        "percent_min": 0,
+        "text": "facility that processes peanuts"
+      },
+      {
+        "id": "en:tree-nut",
+        "is_in_taxonomy": 1,
+        "percent_estimate": 5,
+        "percent_max": 20,
+        "percent_min": 0,
+        "text": "tree nuts",
+        "vegan": "yes",
+        "vegetarian": "yes"
+      }
+    ],
+    "ingredients_analysis": {
+      "en:palm-oil-content-unknown": [
+        "en:facility-that-processes-peanuts"
+      ],
+      "en:vegan-status-unknown": [
+        "en:facility-that-processes-peanuts"
+      ],
+      "en:vegetarian-status-unknown": [
+        "en:facility-that-processes-peanuts"
+      ]
+    },
+    "ingredients_analysis_tags": [
+      "en:palm-oil-free",
+      "en:vegan",
+      "en:vegetarian"
+    ],
+    "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+    "ingredients_from_palm_oil_n": 0,
+    "ingredients_from_palm_oil_tags": [],
+    "ingredients_hierarchy": [
+      "en:edamame",
+      "en:vegetable",
+      "en:legume",
+      "en:pulse",
+      "en:soya",
+      "en:soya-bean",
+      "en:sea-salt",
+      "en:salt",
+      "en:soya-oil",
+      "en:oil-and-fat",
+      "en:vegetable-oil-and-fat",
+      "en:vegetable-oil",
+      "en:facility-that-processes-peanuts",
+      "en:tree-nut",
+      "en:nut"
+    ],
+    "ingredients_lc": "en",
+    "ingredients_n": 6,
+    "ingredients_n_tags": [
+      "6",
+      "1-10"
+    ],
+    "ingredients_non_nutritive_sweeteners_n": 0,
+    "ingredients_original_tags": [
+      "en:edamame",
+      "en:sea-salt",
+      "en:soya-oil",
+      "en:facility-that-processes-peanuts",
+      "en:tree-nut",
+      "en:soya-bean"
+    ],
+    "ingredients_percent_analysis": 1,
+    "ingredients_sweeteners_n": 0,
+    "ingredients_tags": [
+      "en:edamame",
+      "en:vegetable",
+      "en:legume",
+      "en:pulse",
+      "en:soya",
+      "en:soya-bean",
+      "en:sea-salt",
+      "en:salt",
+      "en:soya-oil",
+      "en:oil-and-fat",
+      "en:vegetable-oil-and-fat",
+      "en:vegetable-oil",
+      "en:facility-that-processes-peanuts",
+      "en:tree-nut",
+      "en:nut"
+    ],
+    "ingredients_text": "Edamame (Soybean), Sea Salt, Soybean Oil Contains: Soy Made in a facility that processes peanuts and tree nuts.",
+    "ingredients_text_en": "Edamame (Soybean), Sea Salt, Soybean Oil Contains: Soy Made in a facility that processes peanuts and tree nuts.",
+    "ingredients_text_with_allergens": "Edamame (<span class=\"allergen\">Soybean</span>), Sea Salt, Soybean Oil Contains: Soy Made in a facility that processes peanuts and <span class=\"allergen\">tree nuts</span>.",
+    "ingredients_text_with_allergens_en": "Edamame (<span class=\"allergen\">Soybean</span>), Sea Salt, Soybean Oil Contains: Soy Made in a facility that processes peanuts and <span class=\"allergen\">tree nuts</span>.",
+    "ingredients_that_may_be_from_palm_oil_n": 0,
+    "ingredients_that_may_be_from_palm_oil_tags": [],
+    "ingredients_with_specified_percent_n": 0,
+    "ingredients_with_specified_percent_sum": 0,
+    "ingredients_with_unspecified_percent_n": 5,
+    "ingredients_with_unspecified_percent_sum": 100,
+    "ingredients_without_ciqual_codes": [
+      "en:facility-that-processes-peanuts",
+      "en:tree-nut"
+    ],
+    "ingredients_without_ciqual_codes_n": 2,
+    "ingredients_without_ecobalyse_ids": [
+      "en:edamame",
+      "en:facility-that-processes-peanuts",
+      "en:sea-salt",
+      "en:soya-bean",
+      "en:soya-oil",
+      "en:tree-nut"
+    ],
+    "ingredients_without_ecobalyse_ids_n": 6,
+    "interface_version_created": "20120622",
+    "interface_version_modified": "20150316.jqm2",
+    "known_ingredients_n": 14,
+    "labels": "No gluten, Vegetarian, Kosher, No GMOs, Vegan, Non GMO project, Vegan Action",
+    "labels_hierarchy": [
+      "en:no-gluten",
+      "en:vegetarian",
+      "en:kosher",
+      "en:no-gmos",
+      "en:vegan",
+      "en:non-gmo-project",
+      "en:vegan-action"
+    ],
+    "labels_lc": "en",
+    "labels_old": "No gluten,Vegetarian,Kosher,No GMOs,Vegan,Non GMO project,Vegan Action",
+    "labels_tags": [
+      "en:no-gluten",
+      "en:vegetarian",
+      "en:kosher",
+      "en:no-gmos",
+      "en:vegan",
+      "en:non-gmo-project",
+      "en:vegan-action"
+    ],
+    "lang": "en",
+    "languages": {
+      "en:english": 5
+    },
+    "languages_codes": {
+      "en": 5
+    },
+    "languages_hierarchy": [
+      "en:english"
+    ],
+    "languages_tags": [
+      "en:english",
+      "en:1"
+    ],
+    "last_edit_dates_tags": [
+      "2025-01-05",
+      "2025-01",
+      "2025"
+    ],
+    "last_image_dates_tags": [
+      "2024-03-13",
+      "2024-03",
+      "2024"
+    ],
+    "last_image_t": 1710372452,
+    "last_modified_t": 1736112585,
+    "last_updated_t": 1738823298,
+    "lc": "en",
+    "link": "",
+    "main_countries_tags": [],
+    "manufacturing_places": "",
+    "manufacturing_places_tags": [],
+    "max_imgid": "5",
+    "minerals_tags": [],
+    "misc_tags": [
+      "en:environmental-score-extended-data-not-computed",
+      "en:environmental-score-not-computed",
+      "en:nutriscore-2021-c-2023-c",
+      "en:nutriscore-2021-same-as-2023",
+      "en:nutriscore-computed",
+      "en:nutrition-all-nutriscore-values-known",
+      "en:nutrition-fruits-vegetables-legumes-estimate-from-ingredients",
+      "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+      "en:packagings-empty",
+      "en:packagings-not-complete",
+      "en:packagings-number-of-components-0",
+      "en:main-countries-new-product"
+    ],
+    "no_nutrition_data": "",
+    "nova_group": 3,
+    "nova_group_debug": "",
+    "nova_groups": "3",
+    "nova_groups_markers": {
+      "3": [
+        [
+          "ingredients",
+          "en:salt"
+        ],
+        [
+          "ingredients",
+          "en:vegetable-oil"
+        ]
+      ]
+    },
+    "nova_groups_tags": [
+      "en:3-processed-foods"
+    ],
+    "nucleotides_tags": [],
+    "nutrient_levels": {
+      "fat": "moderate",
+      "salt": "high",
+      "saturated-fat": "moderate",
+      "sugars": "moderate"
+    },
+    "nutrient_levels_tags": [
+      "en:fat-in-moderate-quantity",
+      "en:saturated-fat-in-moderate-quantity",
+      "en:sugars-in-moderate-quantity",
+      "en:salt-in-high-quantity"
+    ],
+    "nutriments": {
+      "calcium": 0.0519,
+      "calcium_100g": 0.173,
+      "calcium_serving": 0.0519,
+      "calcium_unit": "g",
+      "calcium_value": 0.0519,
+      "carbohydrates": 7,
+      "carbohydrates_100g": 23.3,
+      "carbohydrates_serving": 7,
+      "carbohydrates_unit": "g",
+      "carbohydrates_value": 7,
+      "cholesterol": 0,
+      "cholesterol_100g": 0,
+      "cholesterol_serving": 0,
+      "cholesterol_unit": "mg",
+      "cholesterol_value": 0,
+      "energy": 477,
+      "energy-kcal": 114,
+      "energy-kcal_100g": 380,
+      "energy-kcal_serving": 114,
+      "energy-kcal_unit": "kcal",
+      "energy-kcal_value": 114,
+      "energy-kcal_value_computed": 139,
+      "energy_100g": 1590,
+      "energy_serving": 477,
+      "energy_unit": "kcal",
+      "energy_value": 114,
+      "fat": 5,
+      "fat_100g": 16.7,
+      "fat_serving": 5,
+      "fat_unit": "g",
+      "fat_value": 5,
+      "fiber": 5,
+      "fiber_100g": 16.7,
+      "fiber_serving": 5,
+      "fiber_unit": "g",
+      "fiber_value": 5,
+      "fruits-vegetables-legumes-estimate-from-ingredients_100g": 60,
+      "fruits-vegetables-legumes-estimate-from-ingredients_serving": 60,
+      "fruits-vegetables-nuts-estimate-from-ingredients_100g": 65,
+      "fruits-vegetables-nuts-estimate-from-ingredients_serving": 65,
+      "iron": 0.002001,
+      "iron_100g": 0.00667,
+      "iron_serving": 0.002001,
+      "iron_unit": "g",
+      "iron_value": 0.002001,
+      "nova-group": 3,
+      "nova-group_100g": 3,
+      "nova-group_serving": 3,
+      "nutrition-score-fr": 10,
+      "nutrition-score-fr_100g": 10,
+      "potassium": 0.21,
+      "potassium_100g": 0.7,
+      "potassium_serving": 0.21,
+      "potassium_unit": "g",
+      "potassium_value": 0.21,
+      "proteins": 14,
+      "proteins_100g": 46.7,
+      "proteins_serving": 14,
+      "proteins_unit": "g",
+      "proteins_value": 14,
+      "salt": 0.5125,
+      "salt_100g": 1.71,
+      "salt_serving": 0.5125,
+      "salt_unit": "mg",
+      "salt_value": 512.5,
+      "saturated-fat": 1,
+      "saturated-fat_100g": 3.33,
+      "saturated-fat_serving": 1,
+      "saturated-fat_unit": "g",
+      "saturated-fat_value": 1,
+      "sodium": 0.205,
+      "sodium_100g": 0.683,
+      "sodium_serving": 0.205,
+      "sodium_unit": "mg",
+      "sodium_value": 205,
+      "sugars": 2,
+      "sugars_100g": 6.67,
+      "sugars_serving": 2,
+      "sugars_unit": "g",
+      "sugars_value": 2,
+      "trans-fat": 0,
+      "trans-fat_100g": 0,
+      "trans-fat_serving": 0,
+      "trans-fat_unit": "g",
+      "trans-fat_value": 0
+    },
+    "nutriscore": {
+      "2021": {
+        "category_available": 1,
+        "data": {
+          "energy": 1590,
+          "energy_points": 4,
+          "energy_value": 1590,
+          "fiber": 16.7,
+          "fiber_points": 5,
+          "fiber_value": 16.7,
+          "fruits_vegetables_nuts_colza_walnut_olive_oils": 65,
+          "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 2,
+          "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 65,
+          "is_beverage": 0,
+          "is_cheese": 0,
+          "is_fat": 0,
+          "is_water": 0,
+          "negative_points": 15,
+          "positive_points": 7,
+          "proteins": 46.7,
+          "proteins_points": 5,
+          "proteins_value": 46.7,
+          "saturated_fat": 3.33,
+          "saturated_fat_points": 3,
+          "saturated_fat_value": 3.3,
+          "sodium": 683,
+          "sodium_points": 7,
+          "sodium_value": 683,
+          "sugars": 6.67,
+          "sugars_points": 1,
+          "sugars_value": 6.67
+        },
+        "grade": "c",
+        "nutrients_available": 1,
+        "nutriscore_applicable": 1,
+        "nutriscore_computed": 1,
+        "score": 8
+      },
+      "2023": {
+        "category_available": 1,
+        "data": {
+          "components": {
+            "negative": [
+              {
+                "id": "energy",
+                "points": 4,
+                "points_max": 10,
+                "unit": "kJ",
+                "value": 1590
+              },
+              {
+                "id": "sugars",
+                "points": 1,
+                "points_max": 15,
+                "unit": "g",
+                "value": 6.67
+              },
+              {
+                "id": "saturated_fat",
+                "points": 3,
+                "points_max": 10,
+                "unit": "g",
+                "value": 3.33
+              },
+              {
+                "id": "salt",
+                "points": 8,
+                "points_max": 20,
+                "unit": "g",
+                "value": 1.71
+              }
+            ],
+            "positive": [
+              {
+                "id": "fiber",
+                "points": 5,
+                "points_max": 5,
+                "unit": "g",
+                "value": 16.7
+              },
+              {
+                "id": "fruits_vegetables_legumes",
+                "points": 1,
+                "points_max": 5,
+                "unit": "%",
+                "value": 60
+              }
+            ]
+          },
+          "count_proteins": 0,
+          "count_proteins_reason": "negative_points_greater_than_or_equal_to_11",
+          "is_beverage": 0,
+          "is_cheese": 0,
+          "is_fat_oil_nuts_seeds": 0,
+          "is_red_meat_product": 0,
+          "is_water": 0,
+          "negative_points": 16,
+          "negative_points_max": 55,
+          "positive_nutrients": [
+            "fiber",
+            "fruits_vegetables_legumes"
+          ],
+          "positive_points": 6,
+          "positive_points_max": 10
+        },
+        "grade": "c",
+        "nutrients_available": 1,
+        "nutriscore_applicable": 1,
+        "nutriscore_computed": 1,
+        "score": 10
+      }
+    },
+    "nutriscore_2021_tags": [
+      "c"
+    ],
+    "nutriscore_2023_tags": [
+      "c"
+    ],
+    "nutriscore_data": {
+      "components": {
+        "negative": [
+          {
+            "id": "energy",
+            "points": 4,
+            "points_max": 10,
+            "unit": "kJ",
+            "value": 1590
+          },
+          {
+            "id": "sugars",
+            "points": 1,
+            "points_max": 15,
+            "unit": "g",
+            "value": 6.67
+          },
+          {
+            "id": "saturated_fat",
+            "points": 3,
+            "points_max": 10,
+            "unit": "g",
+            "value": 3.33
+          },
+          {
+            "id": "salt",
+            "points": 8,
+            "points_max": 20,
+            "unit": "g",
+            "value": 1.71
+          }
+        ],
+        "positive": [
+          {
+            "id": "fiber",
+            "points": 5,
+            "points_max": 5,
+            "unit": "g",
+            "value": 16.7
+          },
+          {
+            "id": "fruits_vegetables_legumes",
+            "points": 1,
+            "points_max": 5,
+            "unit": "%",
+            "value": 60
+          }
+        ]
+      },
+      "count_proteins": 0,
+      "count_proteins_reason": "negative_points_greater_than_or_equal_to_11",
+      "grade": "c",
+      "is_beverage": 0,
+      "is_cheese": 0,
+      "is_fat_oil_nuts_seeds": 0,
+      "is_red_meat_product": 0,
+      "is_water": 0,
+      "negative_points": 16,
+      "negative_points_max": 55,
+      "positive_nutrients": [
+        "fiber",
+        "fruits_vegetables_legumes"
+      ],
+      "positive_points": 6,
+      "positive_points_max": 10,
+      "score": 10
+    },
+    "nutriscore_grade": "c",
+    "nutriscore_score": 10,
+    "nutriscore_score_opposite": -10,
+    "nutriscore_tags": [
+      "c"
+    ],
+    "nutriscore_version": "2023",
+    "nutrition_data": "on",
+    "nutrition_data_per": "serving",
+    "nutrition_data_prepared": "",
+    "nutrition_data_prepared_per": "100g",
+    "nutrition_grade_fr": "c",
+    "nutrition_grades": "c",
+    "nutrition_grades_tags": [
+      "c"
+    ],
+    "nutrition_score_beverage": 0,
+    "nutrition_score_debug": "",
+    "nutrition_score_warning_fruits_vegetables_legumes_estimate_from_ingredients": 1,
+    "nutrition_score_warning_fruits_vegetables_legumes_estimate_from_ingredients_value": 60,
+    "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients": 1,
+    "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value": 65,
+    "origin": "",
+    "origin_en": "",
+    "origins": "China",
+    "origins_hierarchy": [
+      "en:china"
+    ],
+    "origins_lc": "en",
+    "origins_tags": [
+      "en:china"
+    ],
+    "other_nutritional_substances_tags": [],
+    "packaging_materials_tags": [],
+    "packaging_recycling_tags": [],
+    "packaging_shapes_tags": [],
+    "packaging_text": "",
+    "packaging_text_en": "",
+    "packagings": [],
+    "packagings_complete": 0,
+    "packagings_materials": {},
+    "photographers_tags": [
+      "smoothie-app",
+      "foodvisor"
+    ],
+    "pnns_groups_1": "unknown",
+    "pnns_groups_1_tags": [
+      "unknown",
+      "missing-association"
+    ],
+    "pnns_groups_2": "unknown",
+    "pnns_groups_2_tags": [
+      "unknown",
+      "missing-association"
+    ],
+    "popularity_key": 5,
+    "popularity_tags": [
+      "top-75-percent-scans-2024",
+      "top-80-percent-scans-2024",
+      "top-85-percent-scans-2024",
+      "top-90-percent-scans-2024",
+      "top-50000-us-scans-2024",
+      "top-100000-us-scans-2024",
+      "top-country-us-scans-2024"
+    ],
+    "product_name": "Edamame Beans",
+    "product_name_en": "Edamame Beans",
+    "product_quantity": 510.29141625,
+    "product_quantity_unit": "g",
+    "product_type": "food",
+    "purchase_places": "",
+    "purchase_places_tags": [],
+    "quantity": "18 oz",
+    "removed_countries_tags": [],
+    "rev": 23,
+    "scans_n": 4,
+    "schema_version": 998,
+    "selected_images": {
+      "front": {
+        "display": {
+          "en": "https://images.openfoodfacts.net/images/products/086/000/809/7699/front_en.3.400.jpg"
+        },
+        "small": {
+          "en": "https://images.openfoodfacts.net/images/products/086/000/809/7699/front_en.3.200.jpg"
+        },
+        "thumb": {
+          "en": "https://images.openfoodfacts.net/images/products/086/000/809/7699/front_en.3.100.jpg"
+        }
+      },
+      "ingredients": {
+        "display": {
+          "en": "https://images.openfoodfacts.net/images/products/086/000/809/7699/ingredients_en.15.400.jpg"
+        },
+        "small": {
+          "en": "https://images.openfoodfacts.net/images/products/086/000/809/7699/ingredients_en.15.200.jpg"
+        },
+        "thumb": {
+          "en": "https://images.openfoodfacts.net/images/products/086/000/809/7699/ingredients_en.15.100.jpg"
+        }
+      },
+      "nutrition": {
+        "display": {
+          "en": "https://images.openfoodfacts.net/images/products/086/000/809/7699/nutrition_en.17.400.jpg"
+        },
+        "small": {
+          "en": "https://images.openfoodfacts.net/images/products/086/000/809/7699/nutrition_en.17.200.jpg"
+        },
+        "thumb": {
+          "en": "https://images.openfoodfacts.net/images/products/086/000/809/7699/nutrition_en.17.100.jpg"
+        }
+      }
+    },
+    "serving_quantity": "30",
+    "serving_quantity_unit": "g",
+    "serving_size": "30g",
+    "states": "en:to-be-completed, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-to-be-completed, en:packaging-code-to-be-completed, en:characteristics-to-be-completed, en:origins-completed, en:categories-completed, en:brands-completed, en:packaging-to-be-completed, en:quantity-completed, en:product-name-completed, en:photos-to-be-validated, en:packaging-photo-to-be-selected, en:nutrition-photo-selected, en:ingredients-photo-selected, en:front-photo-selected, en:photos-uploaded",
+    "states_hierarchy": [
+      "en:to-be-completed",
+      "en:nutrition-facts-completed",
+      "en:ingredients-completed",
+      "en:expiration-date-to-be-completed",
+      "en:packaging-code-to-be-completed",
+      "en:characteristics-to-be-completed",
+      "en:origins-completed",
+      "en:categories-completed",
+      "en:brands-completed",
+      "en:packaging-to-be-completed",
+      "en:quantity-completed",
+      "en:product-name-completed",
+      "en:photos-to-be-validated",
+      "en:packaging-photo-to-be-selected",
+      "en:nutrition-photo-selected",
+      "en:ingredients-photo-selected",
+      "en:front-photo-selected",
+      "en:photos-uploaded"
+    ],
+    "states_tags": [
+      "en:to-be-completed",
+      "en:nutrition-facts-completed",
+      "en:ingredients-completed",
+      "en:expiration-date-to-be-completed",
+      "en:packaging-code-to-be-completed",
+      "en:characteristics-to-be-completed",
+      "en:origins-completed",
+      "en:categories-completed",
+      "en:brands-completed",
+      "en:packaging-to-be-completed",
+      "en:quantity-completed",
+      "en:product-name-completed",
+      "en:photos-to-be-validated",
+      "en:packaging-photo-to-be-selected",
+      "en:nutrition-photo-selected",
+      "en:ingredients-photo-selected",
+      "en:front-photo-selected",
+      "en:photos-uploaded"
+    ],
+    "stores": "",
+    "stores_tags": [],
+    "teams": "pain-au-chocolat",
+    "teams_tags": [
+      "pain-au-chocolat"
+    ],
+    "traces": "",
+    "traces_from_ingredients": "",
+    "traces_from_user": "(en) ",
+    "traces_hierarchy": [],
+    "traces_lc": "en",
+    "traces_tags": [],
+    "unique_scans_n": 3,
+    "unknown_ingredients_n": 1,
+    "unknown_nutrients_tags": [],
+    "update_key": "sort",
+    "vitamins_tags": [],
+    "weighers_tags": []
+  },
+  "status": 1,
+  "status_verbose": "product found"
+}


### PR DESCRIPTION
late night stuff but small fixes to add the image into the db schema and insertion. Now I just need to reseed the db I think...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Tap any food log entry to open its nutrition details.
  - Scanning now saves product images; newly scanned items can display images in the app.
- Changes
  - Removed the “Quick Add” shortcut from the header on the scale screen.
  - Improved list rendering with stable item keys for smoother scrolling and navigation.
- Data Updates
  - Under-the-hood database support for product images and serving size, enabling richer item details going forward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->